### PR TITLE
Updates for Spack Support, Round 2 (and add CircleCI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+orbs:
+  circleci-tools: geos-esm/circleci-tools@0.11.0
+
+workflows:
+  build-test:
+    jobs:
+      - build-GEOSgcm:
+          name: build-GEOSgcm-on-<< matrix.compiler >>
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          context: 
+            - docker-hub-creds
+
+jobs:
+  build-GEOSgcm:
+    parameters:
+      compiler:
+        type: string
+    executor: circleci-tools/<< parameters.compiler >>
+    working_directory: /root/project
+    steps:
+      - circleci-tools/checkout_fixture
+      - circleci-tools/mepoclone
+      - circleci-tools/mepodevelop
+      - circleci-tools/checkout_if_exists
+      - circleci-tools/cmake:
+          compiler: << parameters.compiler >>
+      - circleci-tools/buildinstall
+      - circleci-tools/compress_artifacts
+      - store_artifacts:
+          path: /logfiles
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,5 +3,4 @@ esma_set_this ()
 esma_add_library (${this}
   SRCS GEOS_OceanGridComp.F90
   SUBCOMPONENTS MOM6_GEOSPlug MOM_GEOS5PlugMod GEOSdatasea_GridComp
-  DEPENDENCIES GEOSdatasea_GridComp MAPL
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES GEOSdatasea_GridComp MAPL esmf)


### PR DESCRIPTION
Due to insufficient grepping on my part, some remnants of the
"non-canonical" CMake still remain. Apparently these were not necessary
changes for Spack, but they are changes that unify the CMake style of
GEOS to be more like "correct" CMake.

In this go-around, it is mainly finding `INC_ESMF` which I apparently
forgot to grep for last time (I was focused on NetCDF), and some
non-canonical OpenMP calls.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for the meta-issue.