### PR TITLE
Update CircleCI to use Baselibs 7.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,25 @@
 version: 2.1
 
+# Anchors to prevent forgetting to update a version
+baselibs_version: &baselibs_version v7.5.0
+bcs_version: &bcs_version v10.22.3
+
 orbs:
-  circleci-tools: geos-esm/circleci-tools@0.11.0
+  ci: geos-esm/circleci-tools@1
 
 workflows:
   build-test:
     jobs:
-      - build-GEOSgcm:
+      # Build GEOSgcm
+      - ci/build:
           name: build-GEOSgcm-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          context: 
-            - docker-hub-creds
-
-jobs:
-  build-GEOSgcm:
-    parameters:
-      compiler:
-        type: string
-    executor: circleci-tools/<< parameters.compiler >>
-    working_directory: /root/project
-    steps:
-      - circleci-tools/checkout_fixture
-      - circleci-tools/mepoclone
-      - circleci-tools/mepodevelop
-      - circleci-tools/checkout_if_exists
-      - circleci-tools/cmake:
-          compiler: << parameters.compiler >>
-      - circleci-tools/buildinstall
-      - circleci-tools/compress_artifacts
-      - store_artifacts:
-          path: /logfiles
-
+          baselibs_version: *baselibs_version
+          repo: GEOSgcm
+          checkout_fixture: true
+          mepodevelop: true
+          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra


### PR DESCRIPTION
This PR updates the CI here to match GEOSgcm now that https://github.com/GEOS-ESM/GEOSgcm/pull/428 has merged into GEOSgcm `main`

(Of course, this will still fail until the new MOM6 and all is in...but it will be up to date!)