### PR TITLE
Update MOM6: routine maintenance

### DIFF
--- a/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -496,6 +496,9 @@ list( APPEND MOM6_SRCS
    # stochastic physics
    config_src/external/stochastic_physics/get_stochy_pattern.F90
    config_src/external/stochastic_physics/stochastic_physics.F90
+   # database comms
+   config_src/external/database_comms/database_client_interface.F90
+   config_src/external/database_comms/MOM_database_comms.F90
 )
 
 


### PR DESCRIPTION
This PR updates GEOS- MOM6 [CMakeLists.txt](https://github.com/GEOS-ESM/GEOS_OceanGridComp/tree/develop/MOM6_GEOSPlug/mom6_cmake) to be consistent with https://github.com/mom-ocean/MOM6/pull/1582 once that is merged.

This PR does not change answers and by definition, impacts **only** the MOM6 based GEOS coupled model.

Steps to follow:
✅ @sanAkel undraft _this_ PR when @marshallward merges https://github.com/mom-ocean/MOM6/pull/1582
❎ @mathomp4 and/or @tclune please review
❎ @mathomp4 please use your _powers_ to merge
Thank you!