### PR TITLE
Add T_Freeze to available exports from MOM6 ocean

### DIFF
--- a/GEOS_OceanGridComp.F90
+++ b/GEOS_OceanGridComp.F90
@@ -425,6 +425,7 @@ contains
     real, pointer :: TS_FOUND (:,:)
     real, pointer :: SS_FOUND (:,:)
     real, pointer :: FRZMLTe(:,:)
+    real, pointer :: T_Freeze_e(:,:)
 
 ! Diagnostics exports
 
@@ -471,6 +472,7 @@ contains
     real, pointer ::   MASK(:,:)
     real, pointer :: MASK3D(:,:,:)
     real, pointer :: FRZMLT(:,:)
+    real, pointer :: T_Freeze(:,:) ! in deg C
 
     real, pointer :: TWd  (:,:)
     real, pointer :: DEL_TEMP (:,:)
@@ -638,7 +640,8 @@ contains
        endif
        
        if(DO_DATASEA==0) then
-          call MAPL_GetPointer(GEX(OCN), FRZMLT, 'FRZMLT', alloc=.true., _RC)
+          call MAPL_GetPointer(GEX(OCN), FRZMLT,   'FRZMLT', alloc=.true., _RC)
+          call MAPL_GetPointer(GEX(OCN), T_Freeze, 'T_Freeze',alloc=.true.,_RC)
        end if
 
 ! Get pointers to exports
@@ -647,6 +650,7 @@ contains
        call MAPL_GetPointer(EXPORT, TS_FOUND,'TS_FOUND', _RC)
        call MAPL_GetPointer(EXPORT, SS_FOUND,'SS_FOUND', _RC)
        call MAPL_GetPointer(EXPORT, FRZMLTe, 'FRZMLT',   _RC)
+       call MAPL_GetPointer(EXPORT, T_Freeze_e, 'T_Freeze', _RC)
 
 ! Diagnostics exports
 !---------------------------------------------------------
@@ -827,6 +831,16 @@ contains
           end if          
        end if
 
+       if(associated(T_Freeze_e)) then
+          if(DO_DATASEA == 0) then
+             where(WGHT > 0.0 )
+                T_Freeze_e = T_Freeze
+             end where
+          else
+             T_Freeze_e = -1.8
+          end if          
+       end if
+
        if (DUAL_OCEAN) then
           !ALT we might not have FI yet, so let get it again
           call MAPL_GetPointer(GIM(OCNd), FI , 'FRACICE'  , _RC)
@@ -846,7 +860,7 @@ contains
 ! Update orphan points
        if(DO_DATASEA == 0) then
           WGHT=FROCEAN*(1-MASK)
-          Tfreeze=MAPL_TICE-0.054*OrphanSalinity
+          Tfreeze=MAPL_TICE-0.054*OrphanSalinity ! in K
 
           where(wght>0.0)
              TS_FOUND=TS_FOUND+ &

--- a/GEOS_Ocean_StateSpecs.rc
+++ b/GEOS_Ocean_StateSpecs.rc
@@ -43,22 +43,23 @@ category: EXPORT
 #---------------------------------------------------------------------------------------------
 #  VARIABLE                  |   DIMENSIONS        |   Additional Metadata
 #---------------------------------------------------------------------------------------------
-NAME        |   UNITS        |   DIMS   |   VLOC   |   LONG_NAME
+NAME        |   UNITS        |   DIMS   |   VLOC   |   COND  |   LONG_NAME
 #---------------------------------------------------------------------------------------------
-#MASKO       |   1            |   xy     |   N      |   ocean_mask  
-SS_FOUND    |   PSU          |   xy     |   N      |   foundation_salinity_for_interface_layer  
-FRZMLT      |   W m-2        |   xy     |   N      |   freeze_melt_potential  
-TAUX        |   N m-2        |   xy     |   N      |   Agrid_eastward_stress_on_ocean  
-TAUY        |   N m-2        |   xy     |   N      |   Agrid_northward_stress_on_ocean  
-SWHEAT      |   W m-2        |   xyz    |   C      |   solar_heating_rate  
-RFLUX       |   W m-2        |   xy     |   N      |   downward_radiative_heat_flux_at_ocean_bottom  
-DISCHARGE   |   kg m-2 s-1   |   xy     |   N      |   river_discharge_at_ocean_points  
-FROCEAN     |   1            |   xy     |   N      |   fraction_of_gridbox_covered_by_ocean  
-LWFLX       |   W m-2        |   xy     |   N      |   surface_net_downward_longwave_flux  
-SWFLX       |   W m-2        |   xy     |   N      |   surface_net_downward_shortwave_flux  
-SHFLX       |   W m-2        |   xy     |   N      |   upward_sensible_heat_flux  
-QFLUX       |   kg m-2 s-1   |   xy     |   N      |   evaporation  
-SFLX        |   kg m-2 s-1   |   xy     |   N      |   salt_flux_due_to_ice_dynamics  
-RAIN        |   kg m-2 s-1   |   xy     |   N      |   ocean_rainfall  
-SNOW        |   kg m-2 s-1   |   xy     |   N      |   ocean_snowfall  
-PEN_OCN     |   W m-2        |   xy     |   N      |   penetrated_shortwave_flux_at_the_bottom_of_first_ocean_model_layer  
+#MASKO       |   1            |   xy     |   N     |                                   |   ocean_mask  
+SS_FOUND    |   PSU          |   xy     |   N      |                                   |   foundation_salinity_for_interface_layer  
+FRZMLT      |   W m-2        |   xy     |   N      |                                   |   freeze_melt_potential  
+TAUX        |   N m-2        |   xy     |   N      |                                   |   Agrid_eastward_stress_on_ocean  
+TAUY        |   N m-2        |   xy     |   N      |                                   |   Agrid_northward_stress_on_ocean  
+SWHEAT      |   W m-2        |   xyz    |   C      |                                   |   solar_heating_rate  
+RFLUX       |   W m-2        |   xy     |   N      |                                   |   downward_radiative_heat_flux_at_ocean_bottom  
+DISCHARGE   |   kg m-2 s-1   |   xy     |   N      |                                   |   river_discharge_at_ocean_points  
+FROCEAN     |   1            |   xy     |   N      |                                   |   fraction_of_gridbox_covered_by_ocean  
+LWFLX       |   W m-2        |   xy     |   N      |                                   |   surface_net_downward_longwave_flux  
+SWFLX       |   W m-2        |   xy     |   N      |                                   |   surface_net_downward_shortwave_flux  
+SHFLX       |   W m-2        |   xy     |   N      |                                   |   upward_sensible_heat_flux  
+QFLUX       |   kg m-2 s-1   |   xy     |   N      |                                   |   evaporation  
+SFLX        |   kg m-2 s-1   |   xy     |   N      |                                   |   salt_flux_due_to_ice_dynamics  
+RAIN        |   kg m-2 s-1   |   xy     |   N      |                                   |   ocean_rainfall  
+SNOW        |   kg m-2 s-1   |   xy     |   N      |                                   |   ocean_snowfall  
+PEN_OCN     |   W m-2        |   xy     |   N      |                                   |   penetrated_shortwave_flux_at_the_bottom_of_first_ocean_model_layer  
+T_Freeze    |   C            | xy       |   N      |  trim(OCEAN_NAME) == 'MOM6'       |   freezing_temperature_calculated_using_salinity_in_degC

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug_StateSpecs.rc
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug_StateSpecs.rc
@@ -47,6 +47,7 @@ SLV           | m             | xy   | N    | sea_level_with_ice_loading_and_inv
 FRAZIL        | W m-2         | xy   | N    | heating_from_frazil_formation
 MELT_POT      | W m-2         | xy   | N    | heat_that_can_be_used_to_melt_sea_ice
 FRZMLT        | W m-2         | xy   | N    | freeze_melt_potential
+T_Freeze      | C             | xy   | N    | freezing_temperature_calculated_using_salinity
 DH            | m OR kg m-2   | xyz  | C    | DUMMY_EXPORT_layer_thickness
 T             | K             | xyz  | C    | DUMMY_EXPORT_potential_temperature
 S             | PSU           | xyz  | C    | DUMMY_EXPORT_salinity

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug_StateSpecs.rc
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug_StateSpecs.rc
@@ -47,7 +47,7 @@ SLV           | m             | xy   | N    | sea_level_with_ice_loading_and_inv
 FRAZIL        | W m-2         | xy   | N    | heating_from_frazil_formation
 MELT_POT      | W m-2         | xy   | N    | heat_that_can_be_used_to_melt_sea_ice
 FRZMLT        | W m-2         | xy   | N    | freeze_melt_potential
-T_Freeze      | C             | xy   | N    | freezing_temperature_calculated_using_salinity
+T_Freeze      | degC             | xy   | N    | freezing_temperature_calculated_using_salinity
 DH            | m OR kg m-2   | xyz  | C    | DUMMY_EXPORT_layer_thickness
 T             | K             | xyz  | C    | DUMMY_EXPORT_potential_temperature
 S             | PSU           | xyz  | C    | DUMMY_EXPORT_salinity


### PR DESCRIPTION
Purpose of this PR is to: resolve https://github.com/GEOS-ESM/GEOS_OceanGridComp/issues/15. Hence it adds `T_Freeze` as an export from `GEOS_OceanGridComp.F90.`

This modification does not change answers.

**Note**:
1. Because not everyone is interested in `T_Freeze`, there will be no PR to update [HISTORY.AOGCM.rc.tmpl](https://github.com/GEOS-ESM/GEOSgcm_App/blob/develop/HISTORY.AOGCM.rc.tmpl) in [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App) repository.
2. Those (users) who want to output it can help themselves by adding following to their `HISTORY.AOGCM.rc.tmpl`:
```
geosgcm_ocn2dT.template:  '%y4%m2%d2_%h2%n2z.nc4',
...
...
geosgcm_ocn2dT.fields:    'UW'    , 'MOM6', 'US'
...
...
                          'T_Freeze' ,    'OCEAN',
                          ::
```
See ⬇️ for an example plot.
![T_Freeze_in_cpld_test geosgcm_ocn2dT 20000416_1530z](https://user-images.githubusercontent.com/18061653/212579792-3f751620-bca6-4f40-b51f-6d435a6a9f48.png)
