### PR TITLE
Clean up and make FMS (1 or 2) agnostic

### DIFF
--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -40,7 +40,7 @@ module MOM6_GEOSPlugMod
                                       mpp_get_compute_domain,       &
                                       mpp_get_data_domain
 
-  use mpp_parameter_mod,        only: AGRID, BGRID_NE, CGRID_NE, SCALAR_PAIR
+  use MOM_domain_infra,         only: AGRID, BGRID_NE, CGRID_NE, SCALAR_PAIR
 
   use MOM_time_manager,         only: set_calendar_type, time_type
   use MOM_time_manager,         only: set_time, set_date

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -42,9 +42,9 @@ module MOM6_GEOSPlugMod
 
   use mpp_parameter_mod,        only: AGRID, BGRID_NE, CGRID_NE, SCALAR_PAIR
 
-  use time_manager_mod,         only: set_calendar_type, time_type
-  use time_manager_mod,         only: set_time, set_date
-  use time_manager_mod,         only: JULIAN
+  use MOM_time_manager,         only: set_calendar_type, time_type
+  use MOM_time_manager,         only: set_time, set_date
+  use MOM_time_manager,         only: JULIAN
 
   use ocean_model_mod,          only: ocean_model_init,     &
                                       ocean_model_init_sfc, &

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -26,13 +26,14 @@ module MOM6_GEOSPlugMod
   use MAPL
   use MAPL_ConstantsMod,        only: MAPL_TICE
 
-! These MOM dependencies are all we are currently using.
-
-  use MOM_diag_manager_infra,   only: MOM_diag_manager_init, MOM_diag_manager_end
+! FMS dependencies
   use field_manager_mod,        only: field_manager_init, field_manager_end
-
   use mpp_mod,                  only: mpp_exit
-  use fms_mod,                  only: fms_init, fms_end
+
+! MOM dependencies
+  use MOM_diag_manager_infra,   only: MOM_diag_manager_init, MOM_diag_manager_end
+
+  use MOM_coms_infra,           only: MOM_infra_init
   use fms_io_mod,               only: fms_io_exit
 
   use mpp_domains_mod,          only: domain2d, mpp_update_domains, &
@@ -295,7 +296,7 @@ contains
 
     call ESMF_VMGet(VM, mpiCommunicator=Comm, _RC)
 
-    call fms_init(Comm)
+    call MOM_infra_init(Comm)
 
 ! Init MOM stuff
 !---------------

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -28,7 +28,7 @@ module MOM6_GEOSPlugMod
 
 ! These MOM dependencies are all we are currently using.
 
-  use diag_manager_mod,         only: diag_manager_init, diag_manager_end
+  use MOM_diag_manager_infra,   only: MOM_diag_manager_init, MOM_diag_manager_end
   use field_manager_mod,        only: field_manager_init, field_manager_end
 
   use mpp_mod,                  only: mpp_exit
@@ -302,7 +302,7 @@ contains
 
     call field_manager_init
     call set_calendar_type ( JULIAN)
-    call diag_manager_init !SA: could pass time_init, not available before (MOM5)
+    call MOM_diag_manager_init
 
     DT   = set_time (DT_OCEAN, 0)
     Time = set_date (YEAR,MONTH,DAY,HR,MN,SC)
@@ -1012,7 +1012,7 @@ contains
 
     call ocean_model_end (Ocean, Ocean_State, Time) ! SA: this also calls ocean_model_save_restart(...)
 
-    call diag_manager_end(Time )
+    call MOM_diag_manager_end(Time )
     call field_manager_end
     call fms_io_exit
 

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -32,9 +32,8 @@ module MOM6_GEOSPlugMod
 
 ! MOM dependencies
   use MOM_diag_manager_infra,   only: MOM_diag_manager_init, MOM_diag_manager_end
-
   use MOM_coms_infra,           only: MOM_infra_init
-  use fms_io_mod,               only: fms_io_exit
+  use MOM_io_infra,             only: io_infra_end
 
   use mpp_domains_mod,          only: domain2d, mpp_update_domains, &
                                       mpp_get_compute_domain,       &
@@ -1015,7 +1014,7 @@ contains
 
     call MOM_diag_manager_end(Time )
     call field_manager_end
-    call fms_io_exit
+    call io_infra_end
 
     deallocate ( Boundary% u_flux          , &
                  Boundary% v_flux          , &

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -28,7 +28,6 @@ module MOM6_GEOSPlugMod
 
 ! These MOM dependencies are all we are currently using.
 
-  use constants_mod,            only: constants_init
   use diag_manager_mod,         only: diag_manager_init, diag_manager_end
   use field_manager_mod,        only: field_manager_init, field_manager_end
 
@@ -301,7 +300,6 @@ contains
 ! Init MOM stuff
 !---------------
 
-    call constants_init
     call field_manager_init
     call set_calendar_type ( JULIAN)
     call diag_manager_init !SA: could pass time_init, not available before (MOM5)


### PR DESCRIPTION
This PR:
- Cleans up the `MOM6_GEOSPlug.F90` (delete commented lines, add notes).
- (Almost) Removes **direct** dependencies on `FMS`, swapping them using infra wrappers from MOM. This will help us switch from `FMS1` to `FMS2`; whenever that switch happens in GEOS.


✅ No change in answers.
✅ Regression tests pass.