### PR TITLE
Add other mepo styles to mit gitignore

### DIFF
--- a/MIT_GEOS5PlugMod/.gitignore
+++ b/MIT_GEOS5PlugMod/.gitignore
@@ -1,1 +1,3 @@
 /@mit
+/mit
+/mit@


### PR DESCRIPTION
@patricia-nasa reminded me about [mepo styles](https://github.com/GEOS-ESM/mepo/releases/tag/v1.31.0) today and I took a look and the mit repo is only ignored in the prefix-style. This PR adds the bare and postfix styles to the `.gitignore`

