### PR TITLE
Update CI to use Baselibs 7.13.0, add runs to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.23.0
+baselibs_version: &baselibs_version v7.13.0
+bcs_version: &bcs_version v11.00.0
 
 orbs:
   ci: geos-esm/circleci-tools@1
@@ -22,4 +22,34 @@ workflows:
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true
-          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
+
+      # Run AMIP GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
+
+      # Run Coupled GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-coupled-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
+          gcm_ocean_type: MOM6
+          change_layout: false


### PR DESCRIPTION
This PR updates the CI to point to Baselibs 7.13.0 which is the version used by GEOSgcm on `main`

It also adds small runs of GEOSgcm uncoupled and coupled-MOM6 to the CI