### PR TITLE
Updated coarse configuration

### DIFF
--- a/MOM6_GEOSPlug/mom6_app/540x458/MOM_channels_global_tx06v1
+++ b/MOM6_GEOSPlug/mom6_app/540x458/MOM_channels_global_tx06v1
@@ -1,0 +1,6 @@
+! Created by Gustavo Marques (gmarques@ucar.edu) and Frank Bryan (bryan@ucar.edu )
+! Date: 06/25/2020
+! This file specifies restricted channel widths in MOM.  The order is:
+!  [U|V]_width, min_longitude, max_longitude, min_latitude, max_latitude, width
+
+U_width, -6.50,  -5.0, 35.8, 36.4,  12000.0  ! Gibraltar

--- a/MOM6_GEOSPlug/mom6_app/540x458/MOM_input
+++ b/MOM6_GEOSPlug/mom6_app/540x458/MOM_input
@@ -21,9 +21,6 @@ NJGLOBAL = 458                  !
                                 ! The processor layout that was actually used.
 
 ! === module MOM ===
-DIABATIC_FIRST = True           !   [Boolean] default = False
-                                ! If true, apply diabatic and thermodynamic processes, including buoyancy
-                                ! forcing and mass gain or loss, before stepping the dynamics forward.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
@@ -60,7 +57,7 @@ C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! definition of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_fixed_initialization ===
@@ -107,12 +104,13 @@ TOPO_CONFIG = "file"            !
                                 !     USER - call a user modified routine.
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
-MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
+MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
                                 ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
                                 ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
                                 ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
-CHANNEL_CONFIG = "none"         ! default = "none"
+MASKING_DEPTH = 0.0
+CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
                                 !     none - All channels have the grid width.
@@ -123,6 +121,8 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+CHANNEL_LIST_FILE = "MOM_channels_global_tx06v1" 
+
 PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
                                 ! If true, each processor writes its own restart file, otherwise a single
                                 ! restart file is generated
@@ -232,14 +232,14 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! m2 s-1, may be used.
 
 ! === module MOM_thickness_diffuse ===
-KHTH = 600.0                    !   [m2 s-1] default = 0.0
+KHTH = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
-KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
+KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
-KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
+KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
+FGNV_C_MIN = 0.0                !   [m s-1] default = 0.0
                                 ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
                                 ! formulation.
 
@@ -256,11 +256,9 @@ ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
                                 ! total tolerance for SSH is 4 times this value.  The default is
                                 ! 0.5*NK*ANGSTROM, and this should not be set less than about
                                 ! 10^-15*MAXIMUM_DEPTH.
-VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies between the barotropic
-                                ! solution and  the sum of the layer thicknesses.
 
 ! === module MOM_CoriolisAdv ===
+CORIOLIS_SCHEME = "SADOURNY75_ENSTRO"
 BOUND_CORIOLIS = True           !   [Boolean] default = False
                                 ! If true, the Coriolis terms at u-points are bounded by the four estimates of
                                 ! (f+rv)v from the four neighboring v-points, and similarly at v-points.  This
@@ -283,7 +281,7 @@ TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
-KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The velocity scale which is multiplied by the grid spacing to calculate the
                                 ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
@@ -320,7 +318,7 @@ BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
                                 ! (for a backward Euler treatment). In practice, BEBT must be greater than about
                                 ! 0.05.
-DTBT = -0.95                    !   [s or nondim] default = -0.98
+DTBT = -0.98                    !   [s or nondim] default = -0.98
                                 ! The barotropic time step, in s. DTBT is only used with the split explicit time
                                 ! stepping. To set the time step automatically based the maximum stable value
                                 ! use 0, or a negative value gives the fraction of the stable value. Setting
@@ -332,7 +330,7 @@ MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
                                 ! If true, a density-gradient dependent re-stratifying flow is imposed in the
                                 ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
                                 ! only be used if BULKMIXEDLAYER is true.
-FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
+FOX_KEMPER_ML_RESTRAT_COEF = 60.0 !   [nondim] default = 0.0
                                 ! A nondimensional coefficient that is proportional to the ratio of the
                                 ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
                                 ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
@@ -431,11 +429,11 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
                                 !   PPM    - Piecewise Parabolic Method (Colella-Woodward)
 
 ! === module MOM_tracer_hor_diff ===
-KHTR = 600.0                    !   [m2 s-1] default = 0.0
+KHTR = 0.0                    !   [m2 s-1] default = 0.0
                                 ! The background along-isopycnal tracer diffusivity.
-KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
+KHTR_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum along-isopycnal tracer diffusivity.
-KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
+KHTR_MAX = 0.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 
 ! === module MOM_sum_output ===

--- a/MOM6_GEOSPlug/mom6_app/540x458/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/540x458/MOM_override
@@ -1,11 +1,11 @@
 ! Blank file in which we can put "overrides" for parameters
 
-#override DT = 900.0
-#override DT_THERM = 900.0
+#override DT = 450.0
+#override DT_THERM = 450.0
+#override HFREEZE = 10.0
 
 #override NK = 50
 #override USE_REGRIDDING = True
-#override BULKMIXEDLAYER = False
 #override COORD_FILE = "Layer_coord50.nc"
 #override USE_STORED_SLOPES = True
 #override USE_NEUTRAL_DIFFUSION = True
@@ -14,23 +14,53 @@
 #override ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz"
 #override REMAPPING_SCHEME = "PPM_H4"
 #override HMIX_FIXED = 0.5
-#override CFL_TRUNCATE_RAMP_TIME = 7200.
 #override Z_INIT_ALE_REMAPPING = True
 #override ENERGETICS_SFC_PBL = True
-#override USE_MLD_ITERATION = False
 #override MASS_WEIGHT_IN_PRESSURE_GRADIENT = True
-KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
-                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 
 TOPO_FILE = "ocean_topog.nc"
 #override RESTART_CHECKSUMS_REQUIRED = False
 
+#override LAYOUT =  90,2
 
-#override VERBOSITY = 3
-!DEBUG = True
-!FATAL_UNUSED_PARAMS = True
+! WOA'18 T, S initial condition
+#override TEMP_SALT_Z_INIT_FILE = "woa18_04_initial_conditions.nc"
+#override Z_INIT_FILE_PTEMP_VAR = "theta0"
+#override Z_INIT_FILE_SALT_VAR  = "s_an"
+!
+! Diffusion in MEKE and horizontal (KH) diffusivity
+! 
+#override MEKE_GMCOEFF = 0.0
+#override MEKE_GEOMETRIC = True
+#override MEKE_GEOMETRIC_ALPHA = 0.1
+#override MEKE_EQUILIBRIUM_ALT = True
+#override MEKE_EQUILIBRIUM_RESTORE = True
+#override MEKE_RESTORING_TIMESCALE = 1.0E+07
 
-!#override NIPROC = 4
-!#override NJPROC = 4
-#override LAYOUT = 45,2
+#override MEKE_KHTH_FAC = 1.0
+#override MEKE_KHTR_FAC = 1.0
+#override MEKE_VISCOSITY_COEFF_KU = 0.2
+#override MEKE_ALPHA_DEFORM = 1.0
+#override MEKE_ALPHA_RHINES = 1.0
+#override MEKE_ALPHA_EADY = 1.0
+#override MEKE_ALPHA_FRICT = 1.0
+#override MEKE_ALPHA_GRID = 1.0
+#override MEKE_ADVECTION_FACTOR = 1.0
+#override KHTR_MIN = 50.0
+#override NDIFF_INTERIOR_ONLY = True
+
+!#override MEKE_KHTH_FAC = 0.8
+!#override MEKE_KHTR_FAC = 0.8
+#override MEKE_KHMEKE_FAC = 0.5
+!#override MEKE_ALPHA_RHINES = 0.05
+!#override MEKE_ALPHA_EADY = 0.05
+!
+#override KHTR_SLOPE_CFF = 0.25
+#override KH_RES_FN_POWER = 100
+#override SMAGORINSKY_KH = True
+#override SMAG_LAP_CONST = 0.15
+!
+! Lateral Boundary diffusion scheme of Marques 2023
+!
+#override USE_LATERAL_BOUNDARY_DIFFUSION = True
+#override LBD_LINEAR_TRANSITION = True

--- a/MOM6_GEOSPlug/mom6_app/540x458/MOM_parameter_doc.all
+++ b/MOM6_GEOSPlug/mom6_app/540x458/MOM_parameter_doc.all
@@ -11,7 +11,7 @@ ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
 USE_EOS = True                  !   [Boolean] default = True
                                 ! If true,  density is calculated from temperature and salinity with an equation
                                 ! of state.  If USE_EOS is true, ENABLE_THERMODYNAMICS must be true as well.
-DIABATIC_FIRST = True           !   [Boolean] default = False
+DIABATIC_FIRST = False          !   [Boolean] default = False
                                 ! If true, apply diabatic and thermodynamic processes, including buoyancy
                                 ! forcing and mass gain or loss, before stepping the dynamics forward.
 USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
@@ -35,6 +35,11 @@ OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping). If False, use the
                                 ! layered isopycnal algorithm.
+REMAP_AUXILIARY_VARS = False    !   [Boolean] default = False
+                                ! If true, apply ALE remapping to all of the auxiliary 3-dimensional variables
+                                ! that are needed to reproduce across restarts, similarly to what is already
+                                ! being done with the primary state variables.  The default should be changed to
+                                ! true.
 BULKMIXEDLAYER = False          !   [Boolean] default = False
                                 ! If true, use a Kraus-Turner-like bulk mixed layer with transitional buffer
                                 ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
@@ -55,11 +60,11 @@ BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
                                 ! points.
-DT = 900.0                      !   [s]
+DT = 450.0                      !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = 900.0                !   [s] default = 900.0
+DT_THERM = 450.0                !   [s] default = 450.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
@@ -77,7 +82,7 @@ HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
                                 ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth over which to
                                 ! average to find surface flow properties, SSU, SSV. A non-positive value
                                 ! indicates no averaging.
-HFREEZE = -1.0                  !   [m] default = -1.0
+HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
@@ -85,7 +90,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
-DTBT_RESET_PERIOD = 0.0         !   [s] default = 900.0
+DTBT_RESET_PERIOD = 0.0         !   [s] default = 450.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
                                 ! initialization.  If 0, DTBT will be set every dynamics time step. The default
@@ -160,7 +165,7 @@ SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
@@ -267,12 +272,12 @@ TOPO_EDITS_FILE = ""            ! default = ""
                                 ! The file from which to read a list of i,j,z topography overrides.
 ALLOW_LANDMASK_CHANGES = False  !   [Boolean] default = False
                                 ! If true, allow topography overrides to change land mask.
-MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
+MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
                                 ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
                                 ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
                                 ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
-MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
+MASKING_DEPTH = 0.0             !   [m] default = -9999.0
                                 ! The depth below which to mask points as land points, for which all fluxes are
                                 ! zeroed out. MASKING_DEPTH is ignored if it has the special default value.
 MAXIMUM_DEPTH = 6000.0          !   [m]
@@ -283,7 +288,7 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
 ! if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
-CHANNEL_CONFIG = "none"         ! default = "none"
+CHANNEL_CONFIG = "list"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
                                 !     none - All channels have the grid width.
@@ -294,6 +299,14 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+CHANNEL_LIST_FILE = "MOM_channels_global_tx06v1" ! default = "MOM_channel_list"
+                                ! The file from which the list of narrowed channels is read.
+CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
+                                ! If true, the channel configuration list works for any longitudes in the range
+                                ! of -360 to 360.
+FATAL_UNUSED_CHANNEL_WIDTHS = False !   [Boolean] default = False
+                                ! If true, trigger a fatal error if there are any channel widths in
+                                ! CHANNEL_LIST_FILE that do not cause any open face widths to change.
 SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
                                 ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
@@ -399,16 +412,22 @@ USE_NW2_TRACERS = False         !   [Boolean] default = False
 
 ! === module ideal_age_example ===
 DO_IDEAL_AGE = True             !   [Boolean] default = True
-                                ! If true, use an ideal age tracer that is set to 0 age in the mixed layer and
-                                ! ages at unit rate in the interior.
+                                ! If true, use an ideal age tracer that is set to 0 age in the boundary layer
+                                ! and ages at unit rate in the interior.
 DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
                                 ! If true, use an ideal vintage tracer that is set to an exponentially
-                                ! increasing value in the mixed layer and is conserved thereafter.
+                                ! increasing value in the boundary layer and is conserved thereafter.
 DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
                                 ! If true, use an ideal age tracer that is everywhere 0 before
                                 ! IDEAL_AGE_DATED_START_YEAR, but the behaves like the standard ideal age tracer
-                                ! - i.e. is set to 0 age in the mixed layer and ages at unit rate in the
+                                ! - i.e. is set to 0 age in the boundary layer and ages at unit rate in the
                                 ! interior.
+DO_BL_RESIDENCE = False         !   [Boolean] default = False
+                                ! If true, use a residence tracer that is set to 0 age in the interior and ages
+                                ! at unit rate in the boundary layer.
+USE_REAL_BL_DEPTH = False       !   [Boolean] default = False
+                                ! If true, the ideal age tracers will use the boundary layer depth diagnosed
+                                ! from the BL or bulkmixedlayer scheme.
 AGE_IC_FILE = ""                ! default = ""
                                 ! The file in which the age-tracer initial values can be found, or an empty
                                 ! string for internal initialization.
@@ -457,7 +476,6 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  HYBGEN - Hybrid coordinate from the Hycom hybgen code
-                                !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
                                 ! Units of the regridding coordinate.
@@ -485,8 +503,8 @@ MIN_THICKNESS = 0.001           !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer thickness allowed.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! This sets the reconstruction scheme used for vertical remapping for all
-                                ! variables. It can be one of the following schemes: PCM         (1st-order
-                                ! accurate)
+                                ! variables. It can be one of the following schemes:
+                                ! PCM         (1st-order accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PLM_HYBGEN  (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
@@ -498,7 +516,8 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 VELOCITY_REMAPPING_SCHEME = "PPM_H4" ! default = "PPM_H4"
                                 ! This sets the reconstruction scheme used for vertical remapping of velocities.
                                 ! By default it is the same as REMAPPING_SCHEME. It can be one of the following
-                                ! schemes: PCM         (1st-order accurate)
+                                ! schemes:
+                                ! PCM         (1st-order accurate)
                                 ! PLM         (2nd-order accurate)
                                 ! PLM_HYBGEN  (2nd-order accurate)
                                 ! PPM_H4      (3rd-order accurate)
@@ -576,7 +595,7 @@ DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
                                 ! A list of string tuples associating diag_table modules to a coordinate
                                 ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
                                 ! PARAMETER_SUFFIX COORDINATE_NAME".
-DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
+DIAG_MISVAL = 1.0E+20           !   [various] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write a text file
@@ -625,17 +644,17 @@ MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
 MEKE_CT = 50.0                  !   [nondim] default = 50.0
                                 ! A coefficient in the expression for the ratio of barotropic eddy energy and
                                 ! mean column energy (see Jansen et al. 2015).
-MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
+MEKE_GMCOEFF = 0.0              !   [nondim] default = -1.0
                                 ! The efficiency of the conversion of potential energy into MEKE by the
                                 ! thickness mixing parameterization. If MEKE_GMCOEFF is negative, this
                                 ! conversion is not used or calculated.
-MEKE_GEOMETRIC = False          !   [Boolean] default = False
+MEKE_GEOMETRIC = True           !   [Boolean] default = False
                                 ! If MEKE_GEOMETRIC is true, uses the GM coefficient formulation from the
                                 ! GEOMETRIC framework (Marshall et al., 2012).
-MEKE_GEOMETRIC_ALPHA = 0.05     !   [nondim] default = 0.05
+MEKE_GEOMETRIC_ALPHA = 0.1      !   [nondim] default = 0.05
                                 ! The nondimensional coefficient governing the efficiency of the GEOMETRIC
                                 ! thickness diffusion.
-MEKE_EQUILIBRIUM_ALT = False    !   [Boolean] default = False
+MEKE_EQUILIBRIUM_ALT = True     !   [Boolean] default = False
                                 ! If true, use an alternative formula for computing the (equilibrium)initial
                                 ! value of MEKE.
 MEKE_EQUILIBRIUM_RESTORING = False !   [Boolean] default = False
@@ -670,11 +689,11 @@ MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! streamfunction for the MEKE GM source term.
 MEKE_VISC_DRAG = True           !   [Boolean] default = True
                                 ! If true, use the vertvisc_type to calculate the bottom drag acting on MEKE.
-MEKE_KHTH_FAC = 0.0             !   [nondim] default = 0.0
+MEKE_KHTH_FAC = 1.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
-MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
+MEKE_KHTR_FAC = 1.0             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTr.
-MEKE_KHMEKE_FAC = 0.0           !   [nondim] default = 0.0
+MEKE_KHMEKE_FAC = 0.5           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_OLD_LSCALE = False         !   [Boolean] default = False
                                 ! If true, use the old formula for length scale which is a function of grid
@@ -682,10 +701,10 @@ MEKE_OLD_LSCALE = False         !   [Boolean] default = False
 MEKE_MIN_LSCALE = False         !   [Boolean] default = False
                                 ! If true, use a strict minimum of provided length scales rather than harmonic
                                 ! mean.
-MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
+MEKE_RD_MAX_SCALE = False       !   [Boolean] default = False
                                 ! If true, the length scale used by MEKE is the minimum of the deformation
                                 ! radius or grid-spacing. Only used if MEKE_OLD_LSCALE=True
-MEKE_VISCOSITY_COEFF_KU = 0.0   !   [nondim] default = 0.0
+MEKE_VISCOSITY_COEFF_KU = 0.2   !   [nondim] default = 0.0
                                 ! If non-zero, is the scaling coefficient in the expression forviscosity used to
                                 ! parameterize harmonic lateral momentum mixing byunresolved eddies represented
                                 ! by MEKE. Can be negative torepresent backscatter from the unresolved eddies.
@@ -700,19 +719,19 @@ MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
 MEKE_FIXED_TOTAL_DEPTH = True   !   [Boolean] default = True
                                 ! If true, use the nominal bathymetric depth as the estimate of the time-varying
                                 ! ocean depth.  Otherwise base the depth on the total ocean massper unit area.
-MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
+MEKE_ALPHA_DEFORM = 1.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale in the
                                 ! expression for mixing length used in MEKE-derived diffusivity.
-MEKE_ALPHA_RHINES = 0.0         !   [nondim] default = 0.0
+MEKE_ALPHA_RHINES = 1.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the Rhines scale in the expression for
                                 ! mixing length used in MEKE-derived diffusivity.
-MEKE_ALPHA_EADY = 0.0           !   [nondim] default = 0.0
+MEKE_ALPHA_EADY = 1.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the Eady length scale in the
                                 ! expression for mixing length used in MEKE-derived diffusivity.
-MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
+MEKE_ALPHA_FRICT = 1.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale in the
                                 ! expression for mixing length used in MEKE-derived diffusivity.
-MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
+MEKE_ALPHA_GRID = 1.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale in the
                                 ! expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
@@ -725,10 +744,14 @@ MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic frictional
                                 ! energy source.
-MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
+MEKE_ADVECTION_FACTOR = 1.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
                                 ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
+MEKE_ADVECTION_BUG = False      !   [Boolean] default = False
+                                ! If true, recover a bug in the calculation of the barotropic transport for the
+                                ! advection of MEKE.  With the bug, only the transports in the deepest layer are
+                                ! used.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in computing
                                 ! beta in the expression of Rhines scale. Use 1 if full topographic beta effect
@@ -769,10 +792,13 @@ RESOLN_USE_EBT = False          !   [Boolean] default = False
 KHTH_USE_EBT_STRUCT = False     !   [Boolean] default = False
                                 ! If true, uses the equivalent barotropic structure as the vertical structure of
                                 ! thickness diffusivity.
+KD_GL90_USE_EBT_STRUCT = False  !   [Boolean] default = False
+                                ! If true, uses the equivalent barotropic structure as the vertical structure of
+                                ! diffusivity in the GL90 scheme.
 KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
                                 ! The nondimensional coefficient in the Visbeck formula for the interface depth
                                 ! diffusivity
-KHTR_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
+KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
                                 ! The nondimensional coefficient in the Visbeck formula for the epipycnal tracer
                                 ! diffusivity
 USE_STORED_SLOPES = True        !   [Boolean] default = False
@@ -785,6 +811,10 @@ VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
 USE_STANLEY_ISO = False         !   [Boolean] default = False
                                 ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
                                 ! code.
+VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
+                                ! If non-zero, is an upper bound on slopes used in the Visbeck formula for
+                                ! diffusivity. This does not affect the isopycnal slope calculation used within
+                                ! thickness diffusion.
 KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
                                 ! A diapycnal diffusivity that is used to interpolate more sensible values of T
                                 ! & S into thin layers.
@@ -794,10 +824,13 @@ USE_SIMPLER_EADY_GROWTH_RATE = False !   [Boolean] default = False
 VARMIX_KTOP = 2                 !   [nondim] default = 2
                                 ! The layer number at which to start vertical integration of S*N for purposes of
                                 ! finding the Eady growth rate.
+VISBECK_L_SCALE = 0.0           !   [m or nondim] default = 0.0
+                                ! The fixed length scale in the Visbeck formula, or if negative a nondimensional
+                                ! scaling factor relating this length scale squared to the cell areas.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
                                 ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
                                 ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-KH_RES_FN_POWER = 2             !   [nondim] default = 2
+KH_RES_FN_POWER = 100           ! default = 2
                                 ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
                                 ! used, although even integers are more efficient to calculate.  Setting this
                                 ! greater than 100 results in a step-function being used.
@@ -805,7 +838,7 @@ VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
                                 ! A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
                                 ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
                                 ! function affects lateral viscosity, Kh, and not KhTh.
-VISC_RES_FN_POWER = 2           !   [nondim] default = 2
+VISC_RES_FN_POWER = 100         ! default = 100
                                 ! The power of dx/Ld in the Kh resolution function.  Any positive integer may be
                                 ! used, although even integers are more efficient to calculate.  Setting this
                                 ! greater than 100 results in a step-function being used. This function affects
@@ -911,11 +944,14 @@ CHANNEL_DRAG_MAX_BBL_THICK = 5.0 !   [m] default = 5.0
                                 ! proportional to HBBL if USE_JACKSON_PARAM or DRAG_AS_BODY_FORCE is true.
 
 ! === module MOM_thickness_diffuse ===
-KHTH = 600.0                    !   [m2 s-1] default = 0.0
+KHTH = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
+READ_KHTH = False               !   [Boolean] default = False
+                                ! If true, read a file (given by KHTH_FILE) containing the spatially varying
+                                ! horizontal isopycnal height diffusivity.
 KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The minimum horizontal thickness diffusivity.
-KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
+KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! The maximum value of the local diffusive CFL ratio that is permitted for the
@@ -937,21 +973,24 @@ DETANGLE_INTERFACES = False     !   [Boolean] default = False
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is not reliable and is
                                 ! scaled away.
-KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
+KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-FGNV_FILTER_SCALE = 1.0         !   [nondim] default = 1.0
-                                ! A coefficient scaling the vertical smoothing term in the Ferrari et al., 2010,
-                                ! streamfunction formulation.
-FGNV_C_MIN = 0.01               !   [m s-1] default = 0.0
-                                ! A minium wave speed used in the Ferrari et al., 2010, streamfunction
-                                ! formulation.
-FGNV_STRAT_FLOOR = 1.0E-15      !   [nondim] default = 1.0E-15
-                                ! A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,
-                                ! streamfunction formulation, expressed as a fraction of planetary rotation,
-                                ! OMEGA. This should be tiny but non-zero to avoid degeneracy.
 USE_STANLEY_GM = False          !   [Boolean] default = False
                                 ! If true, turn on Stanley SGS T variance parameterization in GM code.
+MEKE_GEOMETRIC_EPSILON = 1.0E-07 !   [s-1] default = 1.0E-07
+                                ! Minimum Eady growth rate used in the calculation of GEOMETRIC thickness
+                                ! diffusivity.
+MEKE_GEOMETRIC_2018_ANSWERS = False !   [Boolean] default = False
+                                ! If true, use expressions in the MEKE_GEOMETRIC calculation that recover the
+                                ! answers from the original implementation.  Otherwise, use expressions that
+                                ! satisfy rotational symmetry.
+MEKE_GEOMETRIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the MEKE_GEOMETRIC calculation.  Values
+                                ! below 20190101 recover the answers from the original implementation, while
+                                ! higher values use expressions that satisfy rotational symmetry.  If both
+                                ! MEKE_GEOMETRIC_2018_ANSWERS and MEKE_GEOMETRIC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 USE_KH_IN_MEKE = False          !   [Boolean] default = False
                                 ! If true, uses the thickness diffusivity calculated here to diffuse MEKE.
 USE_GME = False                 !   [Boolean] default = False
@@ -962,11 +1001,8 @@ USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! sign, for legacy reproducibility.
 STOCH_EOS = False               !   [Boolean] default = False
                                 ! If true, stochastic perturbations are applied to the EOS in the PGF.
-STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+STANLEY_COEFF = -1.0            !   [nondim] default = -1.0
                                 ! Coefficient correlating the temperature gradient and SGS T variance.
-STANLEY_A = 1.0                 !   [not defined] default = 1.0
-                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
-                                ! variance.
 
 ! === module MOM_porous_barriers ===
 PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
@@ -1036,7 +1072,7 @@ ETA_TOLERANCE = 1.0E-06         !   [m] default = 2.5E-09
                                 ! total tolerance for SSH is 4 times this value.  The default is
                                 ! 0.5*NK*ANGSTROM, and this should not be set less than about
                                 ! 10^-15*MAXIMUM_DEPTH.
-VELOCITY_TOLERANCE = 1.0E-04    !   [m s-1] default = 3.0E+08
+VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
                                 ! The tolerance for barotropic velocity discrepancies between the barotropic
                                 ! solution and  the sum of the layer thicknesses.
 CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
@@ -1067,7 +1103,7 @@ CORIOLIS_EN_DIS = False         !   [Boolean] default = False
                                 ! If true, two estimates of the thickness fluxes are used to estimate the
                                 ! Coriolis term, and the one that dissipates energy relative to the other one is
                                 ! used.
-CORIOLIS_SCHEME = "SADOURNY75_ENERGY" ! default = "SADOURNY75_ENERGY"
+CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
                                 ! CORIOLIS_SCHEME selects the discretization for the Coriolis terms. Valid
                                 ! values are:
                                 !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
@@ -1201,15 +1237,17 @@ KH = 0.0                        !   [m2 s-1] default = 0.0
                                 ! The background Laplacian horizontal viscosity.
 KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum value allowed for Laplacian horizontal viscosity, KH.
-KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The velocity scale which is multiplied by the grid spacing to calculate the
                                 ! Laplacian viscosity. The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
                                 ! The amplitude of a latitudinally-dependent background viscosity of the form
                                 ! KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
-SMAGORINSKY_KH = False          !   [Boolean] default = False
+SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
+SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
+                                ! The nondimensional Laplacian Smagorinsky constant, often 0.15.
 LEITH_KH = False                !   [Boolean] default = False
                                 ! If true, use a Leith nonlinear eddy viscosity.
 RES_SCALE_MEKE_VISC = False     !   [Boolean] default = False
@@ -1311,6 +1349,9 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+USE_GL90_IN_SSW = False         !   [Boolean] default = False
+                                ! If true, use simpler method to calculate 1/N^2 in GL90 vertical viscosity
+                                ! coefficient. This method is valid in stacked shallow water mode.
 KV_ML_INVZ2 = 0.0               !   [m2 s-1] default = 0.0
                                 ! An extra kinematic viscosity in a mixed layer of thickness HMIX_FIXED, with
                                 ! the actual viscosity scaling as 1/(z*HMIX_FIXED)^2, where z is the distance
@@ -1327,7 +1368,7 @@ CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
 CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations to be reported; the
                                 ! default is CFL_TRUNCATE.
-CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
+CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
                                 ! The time over which the CFL truncation value is ramped up at the beginning of
                                 ! the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
@@ -1447,7 +1488,7 @@ BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
                                 ! (for a backward Euler treatment). In practice, BEBT must be greater than about
                                 ! 0.05.
-DTBT = -0.95                    !   [s or nondim] default = -0.98
+DTBT = -0.98                    !   [s or nondim] default = -0.98
                                 ! The barotropic time step, in s. DTBT is only used with the split explicit time
                                 ! stepping. To set the time step automatically based the maximum stable value
                                 ! use 0, or a negative value gives the fraction of the stable value. Setting
@@ -1462,7 +1503,7 @@ MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
                                 ! If true, a density-gradient dependent re-stratifying flow is imposed in the
                                 ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
                                 ! only be used if BULKMIXEDLAYER is true.
-FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
+FOX_KEMPER_ML_RESTRAT_COEF = 60.0 !   [nondim] default = 0.0
                                 ! A nondimensional coefficient that is proportional to the ratio of the
                                 ! deformation radius to the dominant lengthscale of the submesoscale mixed layer
                                 ! instabilities, times the minimum of the ratio of the mesoscale eddy kinetic
@@ -1502,6 +1543,14 @@ MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
 MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
                                 ! A scaling coefficient for stretching/shrinking the MLD used in the MLE scheme.
                                 ! This simply multiplies MLD wherever used.
+KV_RESTRAT = 0.0                !   [m2 s-1] default = 0.0
+                                ! A small viscosity that sets a floor on the momentum mixing rate during
+                                ! restratification.  If this is positive, it will prevent some possible
+                                ! divisions by zero even if ustar, RESTRAT_USTAR_MIN, and f are all 0.
+RESTRAT_USTAR_MIN = 1.45842E-18 !   [m s-1] default = 1.45842E-18
+                                ! The minimum value of ustar that will be used by the mixed layer
+                                ! restratification module.  This can be tiny, but if this is greater than 0, it
+                                ! will prevent divisions by zero when f and KV_RESTRAT are zero.
 
 ! === module MOM_diagnostics ===
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
@@ -1704,6 +1753,10 @@ KD_KAPPA_SHEAR_0 = 2.0E-05      !   [m2 s-1] default = 2.0E-05
                                 ! The background diffusivity that is used to smooth the density and shear
                                 ! profiles before solving for the diffusivities.  The default is the greater of
                                 ! KD and 1e-7 m2 s-1.
+KD_SEED_KAPPA_SHEAR = 1.0       !   [m2 s-1] default = 1.0
+                                ! A moderately large seed value of diapycnal diffusivity that is used as a
+                                ! starting turbulent diffusivity in the iterations to find an energetically
+                                ! constrained solution for the shear-driven diffusivity.
 KD_TRUNC_KAPPA_SHEAR = 2.0E-07  !   [m2 s-1] default = 2.0E-07
                                 ! The value of shear-driven diffusivity that is considered negligible and is
                                 ! rounded down to 0. The default is 1% of KD_KAPPA_SHEAR_0.
@@ -1735,7 +1788,7 @@ KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
                                 ! If true, massless layers are merged with neighboring massive layers in this
                                 ! calculation.  The default is true and I can think of no good reason why it
                                 ! should be false. This is only used if USE_JACKSON_PARAM is true.
-MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
+MAX_KAPPA_SHEAR_IT = 13         ! default = 13
                                 ! The maximum number of iterations that may be used to estimate the
                                 ! time-averaged diffusivity.
 KAPPA_SHEAR_MAX_KAP_SRC_CHG = 10.0 !   [nondim] default = 10.0
@@ -1778,6 +1831,9 @@ RECLAIM_FRAZIL = True           !   [Boolean] default = True
                                 ! If true, try to use any frazil heat deficit to cool any overlying layers down
                                 ! to the freezing point, thereby avoiding the creation of thin ice when the SST
                                 ! is above the freezing point.
+SALT_EXTRACTION_LIMIT = 0.9999  !   [nondim] default = 0.9999
+                                ! An upper limit on the fraction of the salt in a layer that can be lost to the
+                                ! net surface salt fluxes within a timestep.
 PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
                                 ! If true, use a pressure dependent freezing temperature when making frazil. The
                                 ! default is false, which will be faster but is inappropriate with ice-shelf
@@ -1850,12 +1906,28 @@ NSTAR = 0.2                     !   [nondim] default = 0.2
 MSTAR_CONV_ADJ = 0.0            !   [nondim] default = 0.0
                                 ! Coefficient used for reducing mstar during convection due to reduction of
                                 ! stable density gradient.
-USE_MLD_ITERATION = False       !   [Boolean] default = True
+USE_MLD_ITERATION = True        !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the distance to the bottom of
                                 ! the actively turbulent boundary layer to help set the EPBL length scale.
 EPBL_TRANSITION_SCALE = 0.1     !   [nondim] default = 0.1
                                 ! A scale for the mixing length in the transition layer at the edge of the
                                 ! boundary layer as a fraction of the boundary layer thickness.
+MLD_ITERATION_GUESS = False     !   [Boolean] default = False
+                                ! If true, use the previous timestep MLD as a first guess in the MLD iteration,
+                                ! otherwise use half the ocean depth as the first guess of the boundary layer
+                                ! depth.  The default is false to facilitate reproducibility.
+EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
+                                ! The tolerance for the iteratively determined mixed layer depth.  This is only
+                                ! used with USE_MLD_ITERATION.
+EPBL_MLD_BISECTION = False      !   [Boolean] default = False
+                                ! If true, use bisection with the iterative determination of the self-consistent
+                                ! mixed layer depth.  Otherwise use the false position after a maximum and
+                                ! minimum bound have been evaluated and the returned value or bisection before
+                                ! this.
+EPBL_MLD_MAX_ITS = 20           ! default = 20
+                                ! The maximum number of iterations that can be used to find a self-consistent
+                                ! mixed layer depth.  If EPBL_MLD_BISECTION is true, the maximum number
+                                ! iteractions needed is set by Depth/2^MAX_ITS < EPBL_MLD_TOLERANCE.
 EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
                                 ! The minimum mixing length scale that will be used by ePBL.  The default (0)
                                 ! does not set a minimum.
@@ -1878,10 +1950,10 @@ EPBL_VEL_SCALE_FACTOR = 1.0     !   [nondim] default = 1.0
                                 ! the PBL diffusivity.
 VSTAR_SURF_FAC = 1.2            !   [nondim] default = 1.2
                                 ! The proportionality times ustar to set vstar at the surface.
-USE_LA_LI2016 = False           !   [nondim] default = False
+USE_LA_LI2016 = False           !   [Boolean] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-EPBL_LT = False                 !   [nondim] default = False
+EPBL_LT = False                 !   [Boolean] default = False
                                 ! A logical to use a LT parameterization.
 !EPBL_USTAR_MIN = 1.45842E-18   !   [m s-1]
                                 ! The (tiny) minimum friction velocity used within the ePBL code, derived from
@@ -1932,11 +2004,11 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
                                 !   PPM    - Piecewise Parabolic Method (Colella-Woodward)
 
 ! === module MOM_tracer_hor_diff ===
-KHTR = 600.0                    !   [m2 s-1] default = 0.0
+KHTR = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The background along-isopycnal tracer diffusivity.
 KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum along-isopycnal tracer diffusivity.
-KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
+KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over grid-spacing in passivity,
@@ -1973,7 +2045,7 @@ NDIFF_CONTINUOUS = True         !   [Boolean] default = True
 NDIFF_REF_PRES = -1.0           !   [Pa] default = -1.0
                                 ! The reference pressure (Pa) used for the derivatives of the equation of state.
                                 ! If negative (default), local pressure is used.
-NDIFF_INTERIOR_ONLY = False     !   [Boolean] default = False
+NDIFF_INTERIOR_ONLY = True      !   [Boolean] default = False
                                 ! If true, only applies neutral diffusion in the ocean interior.That is, the
                                 ! algorithm will exclude the surface and bottomboundary layers.
 NDIFF_USE_UNMASKED_TRANSPORT_BUG = False !   [Boolean] default = False
@@ -1983,8 +2055,31 @@ NDIFF_USE_UNMASKED_TRANSPORT_BUG = False !   [Boolean] default = False
 
 ! === module MOM_lateral_boundary_diffusion ===
 ! This module implements lateral diffusion of tracers near boundaries
-USE_LATERAL_BOUNDARY_DIFFUSION = False !   [Boolean] default = False
+USE_LATERAL_BOUNDARY_DIFFUSION = True !   [Boolean] default = False
                                 ! If true, enables the lateral boundary tracer's diffusion module.
+LBD_LINEAR_TRANSITION = True    !   [Boolean] default = False
+                                ! If True, apply a linear transition at the base/top of the boundary.
+                                ! The flux will be fully applied at k=k_min and zero at k=k_max.
+APPLY_LIMITER = True            !   [Boolean] default = True
+                                ! If True, apply a flux limiter in the native grid.
+APPLY_LIMITER_REMAP = False     !   [Boolean] default = False
+                                ! If True, apply a flux limiter in the remapped grid.
+LBD_BOUNDARY_EXTRAP = False     !   [Boolean] default = False
+                                ! Use boundary extrapolation in LBD code
+LBD_REMAPPING_SCHEME = "PLM"    ! default = "PLM"
+                                ! This sets the reconstruction scheme used for vertical remapping for all
+                                ! variables. It can be one of the following schemes: PCM         (1st-order
+                                ! accurate)
+                                ! PLM         (2nd-order accurate)
+                                ! PLM_HYBGEN  (2nd-order accurate)
+                                ! PPM_H4      (3rd-order accurate)
+                                ! PPM_IH4     (3rd-order accurate)
+                                ! PPM_HYBGEN  (3rd-order accurate)
+                                ! WENO_HYBGEN (3rd-order accurate)
+                                ! PQM_IH4IH3  (4th-order accurate)
+                                ! PQM_IH6IH5  (5th-order accurate)
+LBD_DEBUG = False               !   [Boolean] default = False
+                                ! If true, write out verbose debugging data in the LBD module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
                                 ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
                                 ! error rather than issue a WARNING.


### PR DESCRIPTION
This PR updates coarse resolution configuration that provides more realistic simulations. See ⬇️ std (SSH)

- Top left panel: proposed changes in this PR
- Top right panel: without ⬆️ changes
- Bottom: from AVISO

<img width="1281" alt="ssh-std-1992" src="https://github.com/GEOS-ESM/GEOS_OceanGridComp/assets/18061653/ce4943cd-45d3-4619-9209-ee11640ae45d">


This PR does not touch anything else but update `0.66-deg` configuration. In other words, it reproduces answers for everything else!