### PR TITLE
add export of MOM6 C-grid currents

### DIFF
--- a/GEOS_OceanGridComp.F90
+++ b/GEOS_OceanGridComp.F90
@@ -178,6 +178,10 @@ contains
           call MAPL_AddExportSpec (GC, SHORT_NAME = 'SSH', CHILD_ID   = OCN, _RC)
           call MAPL_AddExportSpec (GC, SHORT_NAME = 'PBO', CHILD_ID   = OCN, _RC)
        endif
+       if (trim(OCEAN_NAME) == "MOM6") then
+          call MAPL_AddExportSpec (GC, SHORT_NAME = 'UWC', CHILD_ID   = OCN, _RC)
+          call MAPL_AddExportSpec (GC, SHORT_NAME = 'VWC', CHILD_ID   = OCN, _RC)
+       endif
     end if
 
 !EOS

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -522,6 +522,8 @@ contains
     REAL_, pointer                     :: VW    (:,:)        => null()
     REAL_, pointer                     :: UWB   (:,:)        => null()
     REAL_, pointer                     :: VWB   (:,:)        => null()
+    REAL_, pointer                     :: UWC   (:,:)        => null()
+    REAL_, pointer                     :: VWC   (:,:)        => null()
     REAL_, pointer                     :: SLV   (:,:)        => null()
     REAL_, pointer                     :: FRAZIL(:,:)        => null()
     REAL_, pointer                     :: MELT_POT(:,:)      => null()
@@ -664,6 +666,8 @@ contains
     call MAPL_GetPointer(EXPORT, VW,    'VW'  ,   _RC)
     call MAPL_GetPointer(EXPORT, UWB,   'UWB' ,   _RC)
     call MAPL_GetPointer(EXPORT, VWB,   'VWB' ,   _RC)
+    call MAPL_GetPointer(EXPORT, UWC,   'UWC' ,   _RC)
+    call MAPL_GetPointer(EXPORT, VWC,   'VWC' ,   _RC)
     call MAPL_GetPointer(EXPORT, TW,    'TW'  ,   _RC)
     call MAPL_GetPointer(EXPORT, SW,    'SW'  ,   _RC)
     call MAPL_GetPointer(EXPORT, SLV,   'SLV',    _RC)
@@ -883,6 +887,19 @@ contains
       elsewhere
         VWB =0.0
       end where
+    end if
+
+!   C-grid currents (for CICE dynamics)
+    U = 0.0; V = 0.0
+    call ocean_model_get_UV_surf(Ocean_State, Ocean, 'uc', U, isc, jsc) ! this comes to us in m/s
+    call ocean_model_get_UV_surf(Ocean_State, Ocean, 'vc', V, isc, jsc) ! this comes to us in m/s
+
+    if(associated(UWC )) then
+       UWC = real(U, kind=GeosKind)
+    endif
+
+    if(associated(VWC )) then
+       VWC = real(V, kind=GeosKind)
     end if
 
 ! Optional Exports at GEOS precision

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug_StateSpecs.rc
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug_StateSpecs.rc
@@ -39,6 +39,8 @@ UW            | m s-1         | xy   | N    | surface_Agrid_eastward_velocity
 VW            | m s-1         | xy   | N    | surface_Agrid_northward_velocity
 UWB           | m s-1         | xy   | N    | surface_Bgrid_X_velocity
 VWB           | m s-1         | xy   | N    | surface_Bgrid_Y_velocity
+UWC           | m s-1         | xy   | N    | surface_Cgrid_X_velocity
+VWC           | m s-1         | xy   | N    | surface_Cgrid_Y_velocity
 TW            | K             | xy   | N    | surface_temperature
 SW            | psu           | xy   | N    | surface_salinity
 MOM_2D_MASK   | 1             | xy   | N    | ocean_mask_at_tracer_points


### PR DESCRIPTION
This PR adds two exports for ```MOM6``` U and V currents on its native C-grid. They are introduced to facilitate ```CICE6``` C-grid EVP dynamics scheme. 

Currently ```CICE6``` coupled to ```MOM6``` with B-grid currents (```UWB``` and ```VWB```) and ran B-grid EVP scheme. However, the existing MOM6 grids are tailored to be better suited for C-grid dynamics. The latest ```CICE6``` adds support for C-grid EVP such that the two model components can run compatible dynamics.   

Depends on https://github.com/GEOS-ESM/MOM6/pull/11