### PR TITLE
Update input.nml for medium resolution case

### DIFF
--- a/MOM6_GEOSPlug/mom6_app/540x458/input.nml
+++ b/MOM6_GEOSPlug/mom6_app/540x458/input.nml
@@ -1,6 +1,6 @@
  &MOM_input_nml
          output_directory = './',
-         input_filename = 'r'
+         input_filename = 'n'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'MOM_input',


### PR DESCRIPTION
Let the `default` from clone to be use no restart. User can change: 
>input_filename = `r`

 if they have a restart they would like to use.