### PR TITLE
Use restart to initialize ocean

### DIFF
--- a/MOM6_GEOSPlug/mom6_app/1440x1080/input.nml
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/input.nml
@@ -1,6 +1,6 @@
  &MOM_input_nml
          output_directory = './',
-         input_filename = 'n'
+         input_filename = 'r'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'MOM_input',

--- a/MOM6_GEOSPlug/mom6_app/540x458/input.nml
+++ b/MOM6_GEOSPlug/mom6_app/540x458/input.nml
@@ -1,6 +1,6 @@
  &MOM_input_nml
          output_directory = './',
-         input_filename = 'n'
+         input_filename = 'r'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'MOM_input',

--- a/MOM6_GEOSPlug/mom6_app/72x36/input.nml
+++ b/MOM6_GEOSPlug/mom6_app/72x36/input.nml
@@ -1,6 +1,6 @@
  &MOM_input_nml
          output_directory = './',
-         input_filename = 'n'
+         input_filename = 'r'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'MOM_input',


### PR DESCRIPTION
Change `input.nml` to use existing MOM restart from [this path on discover.](https://github.com/GEOS-ESM/GEOSgcm/wiki/Coupled-model-configurations-(GEOS-MOM6)#sample-restarts)

If the run is on a different platform or wish to start from their own restart, user can follow [this procedure](https://github.com/GEOS-ESM/GEOSgcm/wiki/Coupled-model-configurations-(GEOS-MOM6)#note-2).