### PR TITLE
Maintenance/Update MOM6

### DIFF
--- a/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -173,6 +173,7 @@ list( APPEND MOM6_SRCS
    src/parameterizations/lateral/MOM_MEKE.F90
    src/parameterizations/lateral/MOM_MEKE_types.F90
    src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+   src/parameterizations/lateral/MOM_self_attr_load.F90
    src/parameterizations/lateral/MOM_thickness_diffuse.F90
    src/parameterizations/lateral/MOM_spherical_harmonics.F90
    src/parameterizations/lateral/MOM_tidal_forcing.F90


### PR DESCRIPTION
This PR adjusts [CMakeLists.txt](https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt) to be able to work with updates from this  [PR](https://github.com/mom-ocean/MOM6/pull/1616). 

Specifically, it adds following to the list of files that are to be built: `src/parameterizations/lateral/MOM_self_attr_load.F90`.

In GEOS default setting, answers are preserved. 

**To do:**

- [x] @sanAkel: https://github.com/mom-ocean/MOM6/pull/1616 once has been merged submit this PR.
- [x] @mathomp4 and/or @tclune: https://github.com/orgs/GEOS-ESM/teams/cmake-team please review this PR. 
- [x] @mathomp4: please update our fork: https://github.com/GEOS-ESM/MOM6