### PR TITLE
Refactor DataSea/DataIce IS_FCST to OGCM_IS_FCST

### DIFF
--- a/GEOSdatasea_GridComp/GEOS_DataSeaGridComp.F90
+++ b/GEOSdatasea_GridComp/GEOS_DataSeaGridComp.F90
@@ -214,7 +214,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! In atmospheric forecast mode we do not have future SST and SSS
 !--------------------------------------------------------------
 
-   call MAPL_GetResource(MAPL,IFCST, LABEL="IS_FCST:",        default=0,    _RC)
+   call MAPL_GetResource(MAPL,IFCST, LABEL="OGCM_IS_FCST:",   default=0,    _RC)
    call MAPL_GetResource(MAPL,adjSST,LABEL="SST_ADJ_UND_ICE:",default=0,    _RC)
 
    FCST = IFCST==1

--- a/MIT_GEOS5PlugMod/configs/c12_cs32_01/AGCM.rc
+++ b/MIT_GEOS5PlugMod/configs/c12_cs32_01/AGCM.rc
@@ -507,9 +507,9 @@ DIURNAL_BIOMASS_BURNING: yes
 ANALYSIS_OX_PROVIDER: PCHEM   # options: PCHEM, GMICHEM, STRATCHEM, GOCART
 
 
-# Flag for real-time forecasts (persisted SST) IS_FCST: 1 (AMIP-Style Default: 0)
+# Flag for real-time forecasts (persisted SST) OGCM_IS_FCST: 1 (AMIP-Style Default: 0)
 # -------------------------------------------------------------------------------
-    IS_FCST: 0
+    OGCM_IS_FCST: 0
 
 
 # Time step for aerosol assimilation (GAAS)

--- a/MIT_GEOS5PlugMod/instructions/example_scripts/AGCM.rc
+++ b/MIT_GEOS5PlugMod/instructions/example_scripts/AGCM.rc
@@ -819,9 +819,9 @@ DIURNAL_BIOMASS_BURNING: yes
 ANALYSIS_OX_PROVIDER: PCHEM   # options: PCHEM, GMICHEM, STRATCHEM, GOCART
 
 
-# Flag for real-time forecasts (persisted SST) IS_FCST: 1 (AMIP-Style Default: 0)
+# Flag for real-time forecasts (persisted SST) OGCM_IS_FCST: 1 (AMIP-Style Default: 0)
 # -------------------------------------------------------------------------------
-    IS_FCST: 0
+    OGCM_IS_FCST: 0
 
 
 # Time step for aerosol assimilation (GAAS)


### PR DESCRIPTION
Testing by @sanAkel and @rtodling found that `IS_FCST` was a resource parameter in both the AGCM Grid Comp and in the DataSea and DataIce Grid Comps that was doing different things. In the DataSea and DataIce Grid Comps, it determined persistence of SST/ICE via `MAPL_ReadForcing`. But in the AGCM, it altered IAU handling (I think?).

Either way, there was no good way to set one without setting the other. So, for separability, we rename all the oceanic `IS_FCST` to be `OGCM_IS_FCST`. We keep the AGCM `IS_FCST` as it currently is named unless there is a desire to refactor it from @sdrabenh or others.

This PR has companion PRs:

- https://github.com/GEOS-ESM/GEOSgcm_App/pull/583
- https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/910
