### PR TITLE
Update FMS CMake target

### DIFF
--- a/MOM6_GEOSPlug/CMakeLists.txt
+++ b/MOM6_GEOSPlug/CMakeLists.txt
@@ -10,7 +10,7 @@ esma_add_subdirectories(
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES MAPL fms_r8 mom6
+  DEPENDENCIES MAPL FMS::fms_r8 mom6
   TYPE SHARED
   )
 

--- a/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -522,7 +522,7 @@ endforeach ()
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES fms_r8
+  DEPENDENCIES FMS::fms_r8
   INCLUDES
   $<BUILD_INTERFACE:${MOM6_path}/config_src/memory/dynamic_nonsymmetric>
 #  choose above set MOM6_infra interface


### PR DESCRIPTION
As we move to FMS in Baselibs, we shouldn't use the old `fms_r4` and `fms_r8` targets anymore as they are non-standard. Instead we move to `FMS::fms_r4` and `FMS::fms_r8`.

This in combination with other PRs in GEOSgcm v12 testing.

NOTE: CI is failing since it isn't picking up the v12 testing branch.