### PR TITLE
v2: Remove DEFAULT_2018_ANSWERS as obsolete

### DIFF
--- a/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_input
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_input
@@ -87,8 +87,6 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always

--- a/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
@@ -51,5 +51,4 @@ RESTART_CHECKSUMS_REQUIRED = False
 #override PRESSURE_DEPENDENT_FRAZIL = False
 !
 ! update answers
-#override DEFAULT_2018_ANSWERS = False
 !

--- a/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_parameter_doc.all
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_parameter_doc.all
@@ -150,8 +150,6 @@ BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
                                 ! CHECK_BAD_SURFACE_VALS is true.
 DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
                                 ! This sets the default value for the various _ANSWER_DATE parameters.
-DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ

--- a/MOM6_GEOSPlug/mom6_app/540x458/MOM_parameter_doc.all
+++ b/MOM6_GEOSPlug/mom6_app/540x458/MOM_parameter_doc.all
@@ -150,8 +150,6 @@ BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
                                 ! CHECK_BAD_SURFACE_VALS is true.
 DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
                                 ! This sets the default value for the various _ANSWER_DATE parameters.
-DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ

--- a/MOM6_GEOSPlug/mom6_app/72x36/MOM_parameter_doc.all
+++ b/MOM6_GEOSPlug/mom6_app/72x36/MOM_parameter_doc.all
@@ -127,8 +127,6 @@ BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
                                 ! The value of column thickness below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ


### PR DESCRIPTION
This is a v2 PR for #77 which removes `DEFAULT_2018_ANSWERS`

Closes #77 