### PR TITLE
v2: Update MOM6 Overrides to match current MOM6 results

### DIFF
--- a/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
@@ -53,3 +53,10 @@ RESTART_CHECKSUMS_REQUIRED = False
 ! update answers
 #override DEFAULT_2018_ANSWERS = False
 !
+
+! Overrides to match results from previous MOM6 version
+! See https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.2
+! and https://github.com/mom-ocean/MOM6/pull/1631#issuecomment-2252914251
+
+#override USE_HUYNH_STENCIL_BUG = True
+#override EPBL_ANSWER_DATE = 20231231

--- a/MOM6_GEOSPlug/mom6_app/540x458/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/540x458/MOM_override
@@ -68,3 +68,9 @@ TOPO_FILE = "ocean_topog.nc"
 #override BAD_VAL_SST_MAX = 55.0
 #override BAD_VAL_SST_MIN = -3.0
 
+! Overrides to match results from previous MOM6 version
+! See https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.2
+! and https://github.com/mom-ocean/MOM6/pull/1631#issuecomment-2252914251
+
+#override USE_HUYNH_STENCIL_BUG = True
+#override EPBL_ANSWER_DATE = 20231231

--- a/MOM6_GEOSPlug/mom6_app/72x36/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/72x36/MOM_override
@@ -31,3 +31,10 @@
 #override HFREEZE = 10.0
 #override BAD_VAL_SST_MIN = -3.0
 #override BAD_VAL_SSS_MAX = 55.0
+
+! Overrides to match results from previous MOM6 version
+! See https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.2
+! and https://github.com/mom-ocean/MOM6/pull/1631#issuecomment-2252914251
+
+#override USE_HUYNH_STENCIL_BUG = True
+#override EPBL_ANSWER_DATE = 20231231


### PR DESCRIPTION
With the merge of https://github.com/mom-ocean/MOM6/pull/1631 into
our MOM6 fork in [MOM6 geos/v3.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.2)
without any changes, the answers will change.

So, until these can be tested, we set:
```
USE_HUYNH_STENCIL_BUG = True
EPBL_ANSWER_DATE = 20231231
```

in the `MOM_override` files.