### PR TITLE
v3: Support for MOM6 as of 2025-Jan-13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
-# Anchors to prevent forgetting to update a version
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.3.0
+# Anchors in case we need to override the defaults from the orb
+#baselibs_version: &baselibs_version v8.5.0
+#bcs_version: &bcs_version v12.0.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:
@@ -21,7 +21,10 @@ workflows:
           #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
-          mepodevelop: true
+          # V12 code uses a special branch for now.
+          fixture_branch: feature/sdrabenh/gcm_v12
+          # We comment out this as it will "undo" the fixture_branch
+          #mepodevelop: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
 
       # Run AMIP GCM (1 hour, no ExtData)
@@ -45,7 +48,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [ifort]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -8,18 +8,20 @@ jobs:
   require-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v2
+      - uses: mheap/github-action-required-labels@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: minimum
           count: 1
-          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled"
+          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled,github_actions"
           add_comment: true
+          message: "This PR is being prevented from merging because you have not added one of our required labels: {{ provided }}. Please add one so that the PR can be merged."
+
   blocking-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v2
+      - uses: mheap/github-action-required-labels@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -27,3 +29,4 @@ jobs:
           count: 0
           labels: "Contingent - DNA,Needs Lead Approval,Contingent -- Do Not Approve"
           add_comment: true
+          message: "This PR is being prevented from merging because you have added one of our blocking labels: {{ provided }}. You'll need to remove it before this PR can be merged."

--- a/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -1,8 +1,8 @@
 esma_set_this (OVERRIDE mom6)
 
 # This is for selecting the MOM6 infrastructure interface
-## We default to FMS2 and look if something is passed in...
-set (DEFAULT_MOM6_INFRA "FMS2")
+## We default to FMS1 and look if something is passed in...
+set (DEFAULT_MOM6_INFRA "FMS1")
 if (NOT MOM6_INFRA)
   set (MOM6_INFRA ${DEFAULT_MOM6_INFRA})
 endif ()
@@ -69,7 +69,9 @@ list( APPEND MOM6_SRCS
    src/core/MOM_verticalGrid.F90
    src/core/MOM_porous_barriers.F90
    src/diagnostics/MOM_debugging.F90
+   src/diagnostics/MOM_diagnose_MLD.F90
    src/diagnostics/MOM_diagnostics.F90
+   src/diagnostics/MOM_harmonic_analysis.F90
    src/diagnostics/MOM_obsolete_diagnostics.F90
    src/diagnostics/MOM_obsolete_params.F90
    src/diagnostics/MOM_PointAccel.F90
@@ -176,6 +178,7 @@ list( APPEND MOM6_SRCS
    src/parameterizations/lateral/MOM_MEKE_types.F90
    src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
    src/parameterizations/lateral/MOM_self_attr_load.F90
+   src/parameterizations/lateral/MOM_streaming_filter.F90
    src/parameterizations/lateral/MOM_thickness_diffuse.F90
    src/parameterizations/lateral/MOM_spherical_harmonics.F90
    src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -524,7 +527,7 @@ endforeach ()
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES FMS::fms_r8
+  DEPENDENCIES fms_r8
   INCLUDES
   $<BUILD_INTERFACE:${MOM6_path}/config_src/memory/dynamic_nonsymmetric>
 #  choose above set MOM6_infra interface

--- a/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -1,8 +1,8 @@
 esma_set_this (OVERRIDE mom6)
 
 # This is for selecting the MOM6 infrastructure interface
-## We default to FMS1 and look if something is passed in...
-set (DEFAULT_MOM6_INFRA "FMS1")
+## We default to FMS2 and look if something is passed in...
+set (DEFAULT_MOM6_INFRA "FMS2")
 if (NOT MOM6_INFRA)
   set (MOM6_INFRA ${DEFAULT_MOM6_INFRA})
 endif ()
@@ -527,7 +527,7 @@ endforeach ()
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES fms_r8
+  DEPENDENCIES FMS::fms_r8
   INCLUDES
   $<BUILD_INTERFACE:${MOM6_path}/config_src/memory/dynamic_nonsymmetric>
 #  choose above set MOM6_infra interface


### PR DESCRIPTION
This PR has CMake updates needed to support https://github.com/mom-ocean/MOM6/pull/1647 → https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.4

Testing shows it is zero-diff.