### PR TITLE
v3: fixed a bug incorrectly computing FRZMLT

### DIFF
--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -830,9 +830,12 @@ contains
        endif
 
        where(MOM_2D_MASK(:,:)>0.0)
-          FRZMLT = FRAZIL + MELT_POT
+          FRZMLT = MELT_POT
        elsewhere
           FRZMLT = 0.0
+       end where
+       where(MOM_2D_MASK(:,:)>0.0 .and. FRAZIL>0.0)
+          FRZMLT = FRAZIL
        end where
     end if
 


### PR DESCRIPTION
This PR fixed the https://github.com/GEOS-ESM/GEOS_OceanGridComp/issues/85 of computing FRZMLT. This is on top of develop/V3. There is a corresponding [PR](https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/86) for V2.

It is non 0-diff for MOM6 coupled model.