### PR TITLE
v2: Updates for MOM6 PR 1668

### DIFF
--- a/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
@@ -52,10 +52,3 @@ RESTART_CHECKSUMS_REQUIRED = False
 !
 ! update answers
 !
-
-! Overrides to match results from previous MOM6 version
-! See https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.2
-! and https://github.com/mom-ocean/MOM6/pull/1631#issuecomment-2252914251
-
-#override USE_HUYNH_STENCIL_BUG = True
-#override EPBL_ANSWER_DATE = 20231231

--- a/MOM6_GEOSPlug/mom6_app/540x458/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/540x458/MOM_override
@@ -67,10 +67,3 @@ TOPO_FILE = "ocean_topog.nc"
 #override BAD_VAL_SSS_MAX = 75.0
 #override BAD_VAL_SST_MAX = 55.0
 #override BAD_VAL_SST_MIN = -3.0
-
-! Overrides to match results from previous MOM6 version
-! See https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.2
-! and https://github.com/mom-ocean/MOM6/pull/1631#issuecomment-2252914251
-
-#override USE_HUYNH_STENCIL_BUG = True
-#override EPBL_ANSWER_DATE = 20231231

--- a/MOM6_GEOSPlug/mom6_app/72x36/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/72x36/MOM_override
@@ -31,10 +31,3 @@
 #override HFREEZE = 10.0
 #override BAD_VAL_SST_MIN = -3.0
 #override BAD_VAL_SSS_MAX = 55.0
-
-! Overrides to match results from previous MOM6 version
-! See https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv3.2
-! and https://github.com/mom-ocean/MOM6/pull/1631#issuecomment-2252914251
-
-#override USE_HUYNH_STENCIL_BUG = True
-#override EPBL_ANSWER_DATE = 20231231

--- a/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -524,9 +524,6 @@ list( APPEND MOM6_SRCS
    config_src/external/ODA_hooks/ocean_da_types.F90
    config_src/external/ODA_hooks/write_ocean_obs.F90
    # tracer
-   config_src/external/GFDL_ocean_BGC/FMS_coupler_util.F90
-   config_src/external/GFDL_ocean_BGC/generic_tracer.F90
-   config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
    config_src/external/GFDL_ocean_BGC/MOM_generic_tracer.F90
    # drifters-particles
    config_src/external/drifters/MOM_particles.F90


### PR DESCRIPTION
This PR has updates for building MOM6 with changes from https://github.com/mom-ocean/MOM6/pull/1668

We also remove these lines:
```
#override USE_HUYNH_STENCIL_BUG = True
#override EPBL_ANSWER_DATE = 20231231
```
from the `MOM_override` files. Tests by @sinakhani show that while it is non-zero-diff, it is still "good" and it brings us closer to the defaults from MOM6.