### PR TITLE
v2: Magnitude of the surface stress passing into the MOM6

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, labeled, unlabeled, edited, synchronize]
 
 jobs:
-  require-label:
+  require-coupled-label:
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v5
@@ -14,9 +14,35 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled,github_actions"
+          labels: "0 diff coupled,non 0-diff coupled"
           add_comment: true
-          message: "This PR is being prevented from merging because you have not added one of our required labels: {{ provided }}. Please add one so that the PR can be merged."
+          message: "This PR is being prevented from merging because you have not added one of our required labels to say if they are 0-diff or non-0-diff for coupled runs: {{ provided }}. Please add so that the PR can be merged."
+
+  require-dataatm-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: minimum
+          count: 1
+          labels: "0 diff dataatm,non 0-diff dataatm"
+          add_comment: true
+          message: "This PR is being prevented from merging because you have not added one of our required labels to say if they are 0-diff or non-0-diff for dataatm runs: {{ provided }}. Please add so that the PR can be merged."
+
+  require-dataocean-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: minimum
+          count: 1
+          labels: "0 diff dataocean,non 0-diff dataocean"
+          add_comment: true
+          message: "This PR is being prevented from merging because you have not added one of our required labels to say if they are 0-diff or non-0-diff for dataocean runs: {{ provided }}. Please add so that the PR can be merged."
 
   blocking-label:
     runs-on: ubuntu-latest

--- a/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -773,6 +773,13 @@ contains
     Boundary%U_flux  (isc:iec,jsc:jec)= real( (U*cos_rot - V*sin_rot), kind=KIND(Boundary%p))
     Boundary%V_flux  (isc:iec,jsc:jec)= real( (U*sin_rot + V*cos_rot), kind=KIND(Boundary%p))
 
+!Calculate the magnitude of the stress on the ocean [Pa]
+!-------------------------------------------------------                                      
+   U = 0.0; V = 0.0
+   U = real ( TAUX*(1.-AICE) - TAUXBOT*AICE )**2
+   V = real ( TAUY*(1.-AICE) - TAUYBOT*AICE )**2
+   Boundary%stress_mag     (isc:iec,jsc:jec)= real( (U+V)**0.5, kind=KIND(Boundary%p) )      
+
 ! Set the time for MOM
 !---------------------
 
@@ -891,11 +898,9 @@ contains
        elsewhere
           FRZMLT = 0.0
        end where
-
-       where(MOM_2D_MASK(:,:)>0.0 .and. FRAZIL(:,:) > 0.0)
+       where(MOM_2D_MASK(:,:)>0.0 .and. FRAZIL>0.0)
           FRZMLT = FRAZIL
-       endwhere
-
+       end where
     end if
 
 !   freezing temperature (deg C)
@@ -926,6 +931,8 @@ contains
        print *, 'Both UW and VW MUST be allocated.'
        ASSERT_(.false.)
     endif
+
+
 
 !   B-grid currents (for CICE dynamics)
     U = 0.0; V = 0.0

--- a/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
@@ -51,4 +51,4 @@ RESTART_CHECKSUMS_REQUIRED = False
 #override PRESSURE_DEPENDENT_FRAZIL = False
 !
 ! update answers
-!
+


### PR DESCRIPTION
This is a PR to fix a bug in the imported stress magnitude into MOM6. Please see [#112 ](https://github.com/GEOS-ESM/GEOS_OceanGridComp/issues/112#issuecomment-3254559174) for more discussion. This PR is a zero-diff for AMIP, but non-zero diff for atm-ocn-seaice coupled model and dataatm. 