### PR TITLE
Update MOM6 ocean layouts for o720 and o2880 resolutions

### DIFF
--- a/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/1440x1080/MOM_override
@@ -1,6 +1,6 @@
 ! Blank file in which we can put "overrides" for parameters
 
-LAYOUT = 36, 30
+LAYOUT = 48, 40
 #override DT = 450
 #override DT_THERM = 450
 HFREEZE = 2.0

--- a/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
@@ -1,6 +1,6 @@
 ! Blank file in which we can put "overrides" for parameters
 
-LAYOUT = 36, 30
+LAYOUT = 36, 28
 #override DT = 450
 #override DT_THERM = 450
 HFREEZE = 2.0

--- a/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
@@ -1,6 +1,6 @@
 ! Blank file in which we can put "overrides" for parameters
 
-LAYOUT = 36, 20
+LAYOUT = 36, 30
 #override DT = 450
 #override DT_THERM = 450
 HFREEZE = 2.0
@@ -69,9 +69,9 @@ RESTART_CHECKSUMS_REQUIRED = False
 
 !! Updates for MLD  !! SK
 
-#override FOX_KEMPER_ML_RESTRAT_COEF = 1.0 
+#override FOX_KEMPER_ML_RESTRAT_COEF = 1.0
 #override MLE_FRONT_LENGTH = 500.0
-#override MLE%USE_BODNER23 = True 
+#override MLE%USE_BODNER23 = True
 #override MLE%CR = 0.038
 #override MLE%BLD_DECAYING_TFILTER = 8.64E+04
 #override MLE%MLD_DECAYING_TFILTER = 2.592E+06

--- a/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
@@ -1,6 +1,6 @@
 ! Blank file in which we can put "overrides" for parameters
 
-LAYOUT = 72, 28
+LAYOUT = 48, 40
 #override DT = 450
 #override DT_THERM = 450
 HFREEZE = 2.0

--- a/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/2880x2240/MOM_override
@@ -1,6 +1,6 @@
 ! Blank file in which we can put "overrides" for parameters
 
-LAYOUT = 36, 28
+LAYOUT = 72, 28
 #override DT = 450
 #override DT_THERM = 450
 HFREEZE = 2.0

--- a/MOM6_GEOSPlug/mom6_app/720x576/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/720x576/MOM_override
@@ -1,6 +1,6 @@
 ! Blank file in which we can put "overrides" for parameters
 
-LAYOUT = 45, 24
+LAYOUT = 40, 48
 #override DT = 450
 #override DT_THERM = 450
 HFREEZE = 2.0

--- a/MOM6_GEOSPlug/mom6_app/720x576/MOM_override
+++ b/MOM6_GEOSPlug/mom6_app/720x576/MOM_override
@@ -1,6 +1,6 @@
 ! Blank file in which we can put "overrides" for parameters
 
-LAYOUT = 24, 24
+LAYOUT = 45, 24
 #override DT = 450
 #override DT_THERM = 450
 HFREEZE = 2.0
@@ -69,9 +69,9 @@ RESTART_CHECKSUMS_REQUIRED = False
 
 !! Updates for MLD  !! SK
 
-#override FOX_KEMPER_ML_RESTRAT_COEF = 1.0 
+#override FOX_KEMPER_ML_RESTRAT_COEF = 1.0
 #override MLE_FRONT_LENGTH = 500.0
-#override MLE%USE_BODNER23 = True 
+#override MLE%USE_BODNER23 = True
 #override MLE%CR = 0.038
 #override MLE%BLD_DECAYING_TFILTER = 8.64E+04
 #override MLE%MLD_DECAYING_TFILTER = 2.592E+06


### PR DESCRIPTION
## Description

This PR aligns MOM6 ocean layouts at 1920 ranks. It must be used with https://github.com/GEOS-ESM/GEOSgcm_App/pull/910 so the coupled AGCM and ocean components use matching rank counts.

This enables every supported C180 MOM6 configuration to share the same `20x96` atmospheric layout.

| Ocean grid | NXxNY | Local tile | Ranks |
| --- | ---: | ---: | ---: |
| o720 (720x576) | 40x48 | 18x12 | 1920 |
| o1440 (1440x1080) | 48x40 | 30x27 | 1920 |
| o2880 (2880x2240) | 48x40 | 60x56 | 1920 |

Validated: a C180/o720 coupled run completed successfully.

Should be taken in concert with:

- https://github.com/GEOS-ESM/GEOSgcm_App/pull/910
- https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1492